### PR TITLE
Delete Meta Data by Key on Update

### DIFF
--- a/src/Phoenix/EloquentMeta/MetaTrait.php
+++ b/src/Phoenix/EloquentMeta/MetaTrait.php
@@ -59,7 +59,11 @@ trait MetaTrait
         if ($meta == null) {
             return $this->addMeta($key, $newValue);
         }
-
+		
+		if($newValue == NULL || $newValue == ''){
+			return $this->deleteMeta($key);
+		}
+		
         $obj = $this->getEditableItem($meta, $oldValue);
 
         if ($obj !== false) {


### PR DESCRIPTION
Just a small modification that deletes meta data stored in the DB, if on
updateMeta the value is either NULL or and empty string.

Reason: I found myself wrapping if statements around to check if each value had data, and then run updateMeta by key., it also cleans up the database of existing values which should in fact be deleted if the post data is either NULL or an empty string.